### PR TITLE
Added not equal operator for strict context.

### DIFF
--- a/frontend/Compiler.hs
+++ b/frontend/Compiler.hs
@@ -261,7 +261,7 @@ compileAlts comp alts env
 builtInDyadic :: Assoc Name Instruction
 builtInDyadic
     = [("+", Add), ("-", Sub), ("*", Mul), ("/", Div), 
-       ("==", Eq), ("~=", Ne), (">=", Ge), ("div", Div),
+       ("==", Eq), ("/=", Ne), (">=", Ge), ("div", Div),
        (">", Gt), ("<=", Le), ("<", Lt)] 
 
 


### PR DESCRIPTION
fun x = x /= x

is compiled to:
FunDef: fun 1  
Push 0
Push 1
PushGlobal /=
MkAp
MkAp
Eval
Update 1
Pop 1
Unwind

Instead of directly to:
FunDef: fun 1  
Push 0
Eval
Push 1
Eval
Ne
Update 1
Pop 1
Unwind

The modification compiles fun to the latter.
